### PR TITLE
Fixes #60

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -167,8 +167,8 @@ export default Service.extend({
   },
 
   getScrollTo(container) {
-    // if scrollTo is a function, it's most likely the window
-    if (typeof container.scrollTo === 'function') {
+    // Check if container is the window
+    if (container.self === window) {
       return container.scrollTo;
     // otherwise it's an element
     } else {


### PR DESCRIPTION
- Correctly identifies `window` versus an element passed as container
- Tests are failing locally, but aren't passing in master, either